### PR TITLE
Fix await syntax error in barcode scanner

### DIFF
--- a/src/components/BarcodeScannerModal.tsx
+++ b/src/components/BarcodeScannerModal.tsx
@@ -202,7 +202,7 @@ const BarcodeScannerModal: React.FC<BarcodeScannerModalProps> = ({ onClose, onSc
       await codeReaderRef.current.decodeFromVideoDevice(
         availableCameras[currentCamera]?.deviceId || null,
         videoRef.current,
-        (result: Result | null, error: any) => {
+        async (result: Result | null, error: any) => {
           if (result) {
             const scannedCode = result.getText();
             


### PR DESCRIPTION
Make barcode scanner callback `async` to resolve 'await' syntax error during build.

---

[Open in Web](https://www.cursor.com/agents?id=bc-eeaa6758-257b-4440-93bc-b8da761b9bf6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-eeaa6758-257b-4440-93bc-b8da761b9bf6)