### PR TITLE
Fix saga autocomplete and migrate reading goals

### DIFF
--- a/src/components/AdvancedStatistics.tsx
+++ b/src/components/AdvancedStatistics.tsx
@@ -62,6 +62,18 @@ const AdvancedStatistics: React.FC<AdvancedStatisticsProps> = ({ isOpen, onClose
         }, 0) / librosConTiempo.length
       : 0;
 
+    // Objetivos de lectura
+    const objetivoLibros = state.config.objetivoLecturaAnual || 0;
+    const objetivoPaginas = state.config.objetivoPaginasAnual || 0;
+    
+    // Calcular progreso de objetivos
+    const progresoLibros = objetivoLibros > 0 ? Math.min((librosLeidos / objetivoLibros) * 100, 100) : 0;
+    const progresoPaginas = objetivoPaginas > 0 ? Math.min((paginasLeidas / objetivoPaginas) * 100, 100) : 0;
+    
+    // Calcular libros y páginas restantes para completar objetivos
+    const librosRestantes = Math.max(0, objetivoLibros - librosLeidos);
+    const paginasRestantes = Math.max(0, objetivoPaginas - paginasLeidas);
+
     return {
       totalLibros,
       librosTBR,
@@ -74,7 +86,14 @@ const AdvancedStatistics: React.FC<AdvancedStatisticsProps> = ({ isOpen, onClose
       sagasCompletadas,
       sagasActivas,
       paginasLeidas,
-      tiempoPromedio: Math.round(tiempoPromedio)
+      tiempoPromedio: Math.round(tiempoPromedio),
+      // Objetivos
+      objetivoLibros,
+      objetivoPaginas,
+      progresoLibros,
+      progresoPaginas,
+      librosRestantes,
+      paginasRestantes
     };
   }, [state]);
 
@@ -343,6 +362,83 @@ const AdvancedStatistics: React.FC<AdvancedStatisticsProps> = ({ isOpen, onClose
                   </div>
                 )}
 
+              </div>
+            </motion.div>
+          )}
+
+          {/* Objetivos de Lectura */}
+          {(statistics.objetivoLibros > 0 || statistics.objetivoPaginas > 0) && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.65 }}
+              className="bg-white dark:bg-slate-700 rounded-xl p-6 shadow-lg border border-slate-200 dark:border-slate-600"
+            >
+              <h4 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center space-x-2">
+                <Target className="h-5 w-5 text-green-500" />
+                <span>Objetivos de Lectura</span>
+              </h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {/* Objetivo de Libros */}
+                {statistics.objetivoLibros > 0 && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                        Libros Leídos
+                      </span>
+                      <span className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {statistics.librosLeidos} / {statistics.objetivoLibros}
+                      </span>
+                    </div>
+                    <div className="w-full bg-slate-200 dark:bg-slate-600 rounded-full h-2">
+                      <div 
+                        className="bg-green-500 h-2 rounded-full transition-all duration-300"
+                        style={{ width: `${statistics.progresoLibros}%` }}
+                      />
+                    </div>
+                    <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+                      <span>{statistics.progresoLibros.toFixed(1)}% completado</span>
+                      <span>{statistics.librosRestantes} libros restantes</span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Objetivo de Páginas */}
+                {statistics.objetivoPaginas > 0 && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                        Páginas Leídas
+                      </span>
+                      <span className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {statistics.paginasLeidas.toLocaleString()} / {statistics.objetivoPaginas.toLocaleString()}
+                      </span>
+                    </div>
+                    <div className="w-full bg-slate-200 dark:bg-slate-600 rounded-full h-2">
+                      <div 
+                        className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                        style={{ width: `${statistics.progresoPaginas}%` }}
+                      />
+                    </div>
+                    <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+                      <span>{statistics.progresoPaginas.toFixed(1)}% completado</span>
+                      <span>{statistics.paginasRestantes.toLocaleString()} páginas restantes</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+              
+              {/* Resumen de objetivos */}
+              <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
+                <p className="text-sm text-green-800 dark:text-green-200">
+                  <strong>Estado general:</strong> {
+                    statistics.progresoLibros >= 100 && statistics.progresoPaginas >= 100 
+                      ? '¡Todos los objetivos completados! 🎉' 
+                      : statistics.progresoLibros >= 50 || statistics.progresoPaginas >= 50
+                      ? '¡Buen progreso! Sigue así 💪'
+                      : '¡Sigue leyendo para alcanzar tus objetivos! 📚'
+                  }
+                </p>
               </div>
             </motion.div>
           )}

--- a/src/components/TBRForm.tsx
+++ b/src/components/TBRForm.tsx
@@ -5,6 +5,7 @@ import { useAppState } from '../context/AppStateContext';
 import { Libro, BookData } from '../types';
 import { fetchBookData } from '../services/googleBooksAPI';
 import BookTitleAutocomplete from './BookTitleAutocomplete';
+import SagaAutocomplete from './SagaAutocomplete';
 import ISBNInputModal from './ISBNInputModal';
 import BarcodeScannerModal from './BarcodeScannerModal';
 import BulkScanModal from './BulkScanModal';
@@ -15,6 +16,7 @@ const TBRForm: React.FC = () => {
   const [titulo, setTitulo] = useState('');
   const [autor, setAutor] = useState('');
   const [paginas, setPaginas] = useState('');
+  const [sagaName, setSagaName] = useState('');
   const [isExpanded, setIsExpanded] = useState(false);
   const [showISBNInput, setShowISBNInput] = useState(false);
   const [showBarcodeScanner, setShowBarcodeScanner] = useState(false);
@@ -63,6 +65,7 @@ const TBRForm: React.FC = () => {
       titulo: titulo.trim(),
       autor: autor.trim() || undefined,
       paginas: paginas ? parseInt(paginas) : undefined,
+      sagaName: sagaName.trim() || undefined,
       isbn: selectedBookData?.isbn,
       publicacion: selectedBookData?.publicacion,
       editorial: selectedBookData?.editorial,
@@ -96,6 +99,7 @@ const TBRForm: React.FC = () => {
       titulo: bookData.titulo,
       autor: bookData.autor,
       paginas: bookData.paginas,
+      sagaName: bookData.sagaName,
       isbn: bookData.isbn,
       publicacion: bookData.publicacion,
       editorial: bookData.editorial,
@@ -121,6 +125,7 @@ const TBRForm: React.FC = () => {
     setTitulo('');
     setAutor('');
     setPaginas('');
+    setSagaName('');
     setIsExpanded(false);
     setSelectedBookData(null);
     setScanStatus('idle');
@@ -292,14 +297,24 @@ const TBRForm: React.FC = () => {
             </div>
           </div>
 
-          <div>
-            <input
-              type="number"
-              value={paginas}
-              onChange={(e) => setPaginas(e.target.value)}
-              placeholder="Páginas (opcional)"
-              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-warning-500 focus:border-transparent"
-            />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <input
+                type="number"
+                value={paginas}
+                onChange={(e) => setPaginas(e.target.value)}
+                placeholder="Páginas (opcional)"
+                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-warning-500 focus:border-transparent"
+              />
+            </div>
+            
+            <div>
+              <SagaAutocomplete
+                value={sagaName}
+                onChange={setSagaName}
+                placeholder="Nombre de la saga (opcional)"
+              />
+            </div>
           </div>
 
           {/* Scan Status */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -248,6 +248,7 @@ export interface BookData {
   titulo: string;
   autor?: string;
   paginas?: number;
+  sagaName?: string;
   isbn?: string;
   publicacion?: number;
   editorial?: string;


### PR DESCRIPTION
Implement saga autocomplete for TBR, fix saga creation/assignment on book edit, and display reading goals in advanced statistics.

The `UPDATE_BOOK` action now correctly handles saga assignments: if a new saga name is provided, it creates a new saga; if an existing saga name is used, it links to it; and if the saga name is cleared, it removes the association.

---

[Open in Web](https://www.cursor.com/agents?id=bc-555c7f90-5ead-43e9-8922-0783412e4c93) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-555c7f90-5ead-43e9-8922-0783412e4c93)