### PR TITLE
Adjust game economy and reset progress

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -106,20 +106,30 @@ const BookCard: React.FC<BookCardProps> = ({ book, type, onDelete, onEdit, varia
     // Verificar si el sistema de puntos/dinero está habilitado
     if (state.config.sistemaPuntosHabilitado) {
       if (state.config.modoDinero) {
-        // Modo dinero - usar costo fijo por libro
-        const costoFijo = state.config.dineroParaComprar || 15.0;
+        // Modo dinero - calcular costo por páginas
+        const paginas = book.paginas || 0;
+        const costoPorPagina = state.config.costoPorPagina || 0.25;
+        const costoTotal = paginas * costoPorPagina;
         
-        if (state.dineroActual < costoFijo) {
+        if (costoTotal <= 0) {
+          showError(
+            'Libro sin páginas',
+            'No se puede calcular el costo de un libro sin información de páginas.'
+          );
+          return;
+        }
+        
+        if (state.dineroActual < costoTotal) {
           showError(
             'Dinero insuficiente',
-            `Necesitas $${costoFijo.toFixed(2)} para comprar este libro. Tienes $${state.dineroActual.toFixed(2)}.`
+            `Necesitas $${costoTotal.toFixed(2)} para comprar este libro (${paginas} páginas × $${costoPorPagina.toFixed(2)}/página). Tienes $${state.dineroActual.toFixed(2)}.`
           );
           return;
         }
         
         showConfirm(
           'Comprar libro con dinero',
-          `¿Quieres comprar "${book.titulo}" por $${costoFijo.toFixed(2)}?\n\nDinero actual: $${state.dineroActual.toFixed(2)}\nDinero después de la compra: $${(state.dineroActual - costoFijo).toFixed(2)}`,
+          `¿Quieres comprar "${book.titulo}" por $${costoTotal.toFixed(2)}?\n\nDetalles:\n• Páginas: ${paginas}\n• Costo por página: $${costoPorPagina.toFixed(2)}\n• Costo total: $${costoTotal.toFixed(2)}\n\nDinero actual: $${state.dineroActual.toFixed(2)}\nDinero después de la compra: $${(state.dineroActual - costoTotal).toFixed(2)}`,
           () => {
             dispatch({ 
               type: 'COMPRAR_LIBRO_CON_DINERO', 
@@ -595,7 +605,14 @@ const BookCard: React.FC<BookCardProps> = ({ book, type, onDelete, onEdit, varia
               <span>
                 {state.config.sistemaPuntosHabilitado 
                   ? state.config.modoDinero
-                    ? `Comprar ($${state.config.dineroParaComprar || 15.0})`
+                    ? (() => {
+                        const paginas = book.paginas || 0;
+                        const costoPorPagina = state.config.costoPorPagina || 0.25;
+                        const costoTotal = paginas * costoPorPagina;
+                        return costoTotal > 0 
+                          ? `Comprar ($${costoTotal.toFixed(2)})`
+                          : 'Comprar';
+                      })()
                     : `Comprar (${state.config.puntosParaComprar || 25} pts)`
                   : 'Comprar'
                 }

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -594,7 +594,9 @@ const BookCard: React.FC<BookCardProps> = ({ book, type, onDelete, onEdit, varia
               <ShoppingCart className="h-3 w-3" />
               <span>
                 {state.config.sistemaPuntosHabilitado 
-                  ? `Comprar (${state.config.puntosParaComprar || 25} pts)`
+                  ? state.config.modoDinero
+                    ? `Comprar ($${state.config.dineroParaComprar || 15.0})`
+                    : `Comprar (${state.config.puntosParaComprar || 25} pts)`
                   : 'Comprar'
                 }
               </span>

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -106,30 +106,20 @@ const BookCard: React.FC<BookCardProps> = ({ book, type, onDelete, onEdit, varia
     // Verificar si el sistema de puntos/dinero está habilitado
     if (state.config.sistemaPuntosHabilitado) {
       if (state.config.modoDinero) {
-        // Modo dinero - calcular costo por páginas
-        const paginas = book.paginas || 0;
-        const costoPorPagina = state.config.costoPorPagina || 0.25;
-        const costoTotal = paginas * costoPorPagina;
+        // Modo dinero - usar costo fijo por libro
+        const costoFijo = state.config.dineroParaComprar || 15.0;
         
-        if (costoTotal <= 0) {
-          showError(
-            'Libro sin páginas',
-            'No se puede calcular el costo de un libro sin información de páginas.'
-          );
-          return;
-        }
-        
-        if (state.dineroActual < costoTotal) {
+        if (state.dineroActual < costoFijo) {
           showError(
             'Dinero insuficiente',
-            `Necesitas $${costoTotal.toFixed(2)} para comprar este libro (${paginas} páginas × $${costoPorPagina.toFixed(2)}/página). Tienes $${state.dineroActual.toFixed(2)}.`
+            `Necesitas $${costoFijo.toFixed(2)} para comprar este libro. Tienes $${state.dineroActual.toFixed(2)}.`
           );
           return;
         }
         
         showConfirm(
           'Comprar libro con dinero',
-          `¿Quieres comprar "${book.titulo}" por $${costoTotal.toFixed(2)}?\n\nDetalles:\n• Páginas: ${paginas}\n• Costo por página: $${costoPorPagina.toFixed(2)}\n• Costo total: $${costoTotal.toFixed(2)}\n\nDinero actual: $${state.dineroActual.toFixed(2)}\nDinero después de la compra: $${(state.dineroActual - costoTotal).toFixed(2)}`,
+          `¿Quieres comprar "${book.titulo}" por $${costoFijo.toFixed(2)}?\n\nDinero actual: $${state.dineroActual.toFixed(2)}\nDinero después de la compra: $${(state.dineroActual - costoFijo).toFixed(2)}`,
           () => {
             dispatch({ 
               type: 'COMPRAR_LIBRO_CON_DINERO', 

--- a/src/components/ConfigForm.tsx
+++ b/src/components/ConfigForm.tsx
@@ -7,7 +7,7 @@ import Dialog from './Dialog';
 
 const ConfigForm: React.FC = () => {
   const { state, dispatch } = useAppState();
-  const { dialog, showSuccess, showError, hideDialog } = useDialog();
+  const { dialog, showSuccess, showError, showConfirm, hideDialog } = useDialog();
   const [config, setConfig] = useState(state.config);
 
   const [availableCameras, setAvailableCameras] = useState<MediaDeviceInfo[]>([]);
@@ -17,16 +17,33 @@ const ConfigForm: React.FC = () => {
 
 
   const handleReset = () => {
-    if (window.confirm('¿Estás seguro de que quieres resetear tu progreso? Esto eliminará todos tus datos de lectura.')) {
-      dispatch({ type: 'IMPORT_DATA', payload: { libros: [], sagas: [] } });
-    }
+    showConfirm(
+      'Resetear Progreso',
+      '¿Estás seguro de que quieres resetear tu progreso? Esto eliminará todos tus datos de lectura, puntos y dinero.',
+      () => {
+        dispatch({ type: 'IMPORT_DATA', payload: { libros: [], sagas: [] } });
+        dispatch({ type: 'RESETEAR_PUNTOS' });
+        dispatch({ type: 'RESETEAR_DINERO' });
+        showSuccess('Progreso reseteado', 'Todos los datos han sido eliminados correctamente.');
+      },
+      undefined,
+      'Resetear',
+      'Cancelar'
+    );
   };
 
   const handleCleanDuplicateSagas = () => {
-    if (window.confirm('¿Estás seguro de que quieres limpiar las sagas duplicadas? Esto eliminará las sagas vacías y duplicadas.')) {
-      dispatch({ type: 'CLEAN_DUPLICATE_SAGAS' });
-      showSuccess('Sagas limpiadas', 'Sagas duplicadas limpiadas correctamente.');
-    }
+    showConfirm(
+      'Limpiar Sagas Duplicadas',
+      '¿Estás seguro de que quieres limpiar las sagas duplicadas? Esto eliminará las sagas vacías y duplicadas.',
+      () => {
+        dispatch({ type: 'CLEAN_DUPLICATE_SAGAS' });
+        showSuccess('Sagas limpiadas', 'Sagas duplicadas limpiadas correctamente.');
+      },
+      undefined,
+      'Limpiar',
+      'Cancelar'
+    );
   };
 
   const handleInputChange = (field: keyof typeof config, value: number) => {

--- a/src/components/ConfigForm.tsx
+++ b/src/components/ConfigForm.tsx
@@ -54,6 +54,12 @@ const ConfigForm: React.FC = () => {
 
   const handleBooleanChange = (field: keyof typeof config, value: boolean) => {
     const newConfig = { ...config, [field]: value };
+    
+    // Si se desactiva el sistema de puntos, también ocultar la sección de progreso
+    if (field === 'sistemaPuntosHabilitado' && !value) {
+      newConfig.mostrarSeccionProgreso = false;
+    }
+    
     setConfig(newConfig);
     dispatch({ type: 'SET_CONFIG', payload: newConfig });
   };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -34,7 +34,7 @@ const Dashboard: React.FC = () => {
       </div>
 
       {/* Progress Section */}
-      {state.config.mostrarSeccionProgreso !== false && (
+      {state.config.mostrarSeccionProgreso !== false && state.config.sistemaPuntosHabilitado && (
         <CollapsibleSection
           title="Progreso y Puntos/Dinero"
           icon={<Trophy className="h-5 w-5" />}

--- a/src/components/DataExportImport.tsx
+++ b/src/components/DataExportImport.tsx
@@ -16,6 +16,7 @@ import {
   HardDrive
 } from 'lucide-react';
 import { useAppState } from '../context/AppStateContext';
+import { useDialog } from '../hooks/useDialog';
 import { ExportData } from '../types';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
@@ -29,6 +30,7 @@ interface DataExportImportProps {
 
 const DataExportImport: React.FC<DataExportImportProps> = ({ isOpen, onClose }) => {
   const { state, dispatch } = useAppState();
+  const { showConfirm } = useDialog();
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
@@ -215,11 +217,20 @@ const DataExportImport: React.FC<DataExportImportProps> = ({ isOpen, onClose }) 
   }, [exportData]);
 
   const clearAllData = useCallback(() => {
-    if (window.confirm('¿Estás seguro de que quieres eliminar todos los datos? Esta acción no se puede deshacer.')) {
-      // Clear all books and reset to initial state
-      dispatch({ type: 'IMPORT_DATA', payload: { libros: [], sagas: [] } });
-      setImportSuccess('Todos los datos han sido eliminados');
-    }
+    showConfirm(
+      'Eliminar todos los datos',
+      '¿Estás seguro de que quieres eliminar todos los datos? Esta acción no se puede deshacer.',
+      () => {
+        // Clear all books and reset to initial state
+        dispatch({ type: 'IMPORT_DATA', payload: { libros: [], sagas: [] } });
+        dispatch({ type: 'RESETEAR_PUNTOS' });
+        dispatch({ type: 'RESETEAR_DINERO' });
+        setImportSuccess('Todos los datos han sido eliminados');
+      },
+      undefined,
+      'Eliminar',
+      'Cancelar'
+    );
   }, [dispatch]);
 
   // Calculate book counts by state

--- a/src/components/ScanHistory.tsx
+++ b/src/components/ScanHistory.tsx
@@ -15,6 +15,7 @@ import {
   RotateCcw
 } from 'lucide-react';
 import { useAppState } from '../context/AppStateContext';
+import { useDialog } from '../hooks/useDialog';
 import { ScanHistory as ScanHistoryType } from '../types';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
@@ -26,6 +27,7 @@ interface ScanHistoryProps {
 
 const ScanHistory: React.FC<ScanHistoryProps> = ({ isOpen, onClose }) => {
   const { state, dispatch } = useAppState();
+  const { showConfirm } = useDialog();
   const [searchTerm, setSearchTerm] = useState('');
   const [filterSuccess, setFilterSuccess] = useState<'all' | 'success' | 'error'>('all');
   const [sortBy, setSortBy] = useState<'timestamp' | 'isbn' | 'titulo'>('timestamp');
@@ -85,9 +87,16 @@ const ScanHistory: React.FC<ScanHistoryProps> = ({ isOpen, onClose }) => {
   }, [state.scanHistory, searchTerm, filterSuccess, sortBy, sortOrder]);
 
   const clearHistory = () => {
-    if (window.confirm('¿Estás seguro de que quieres eliminar todo el historial de escaneos?')) {
-      dispatch({ type: 'CLEAR_SCAN_HISTORY' });
-    }
+    showConfirm(
+      'Eliminar historial',
+      '¿Estás seguro de que quieres eliminar todo el historial de escaneos?',
+      () => {
+        dispatch({ type: 'CLEAR_SCAN_HISTORY' });
+      },
+      undefined,
+      'Eliminar',
+      'Cancelar'
+    );
   };
 
   const getSuccessRate = () => {

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -1068,28 +1068,22 @@ function appReducer(state: AppState, action: Action): AppState {
         return state;
       }
 
-      // Calcular costo basado en páginas del libro
-      const paginas = libro.paginas || 0;
-      const costoPorPagina = state.config.costoPorPagina || 0.25;
-      const costoTotal = paginas * costoPorPagina;
+      // Usar costo fijo por libro
+      const costoFijo = state.config.dineroParaComprar || 15.0;
 
-      if (costoTotal <= 0) {
-        return state; // No se puede comprar un libro sin páginas
-      }
-
-      if (state.dineroActual < costoTotal) {
+      if (state.dineroActual < costoFijo) {
         return state;
       }
 
       // Cambiar el estado del libro de 'wishlist' a 'tbr' (comprado y listo para leer)
       const librosActualizados = state.libros.map(l => 
-        l.id === libroId ? agregarEstadoAlHistorial(l, 'tbr', `Comprado con $${costoTotal.toFixed(2)} (${paginas} páginas × $${costoPorPagina.toFixed(2)}/página)`) : l
+        l.id === libroId ? agregarEstadoAlHistorial(l, 'tbr', `Comprado con $${costoFijo.toFixed(2)}`) : l
       );
 
       return {
         ...state,
         libros: librosActualizados,
-        dineroActual: state.dineroActual - costoTotal,
+        dineroActual: state.dineroActual - costoFijo,
         librosCompradosConDinero: state.librosCompradosConDinero + 1
       };
     }

--- a/src/context/AppStateContext.tsx
+++ b/src/context/AppStateContext.tsx
@@ -1068,22 +1068,28 @@ function appReducer(state: AppState, action: Action): AppState {
         return state;
       }
 
-      // Usar costo fijo por libro
-      const costoFijo = state.config.dineroParaComprar || 15.0;
+      // Calcular costo basado en páginas del libro
+      const paginas = libro.paginas || 0;
+      const costoPorPagina = state.config.costoPorPagina || 0.25;
+      const costoTotal = paginas * costoPorPagina;
 
-      if (state.dineroActual < costoFijo) {
+      if (costoTotal <= 0) {
+        return state; // No se puede comprar un libro sin páginas
+      }
+
+      if (state.dineroActual < costoTotal) {
         return state;
       }
 
       // Cambiar el estado del libro de 'wishlist' a 'tbr' (comprado y listo para leer)
       const librosActualizados = state.libros.map(l => 
-        l.id === libroId ? agregarEstadoAlHistorial(l, 'tbr', `Comprado con $${costoFijo.toFixed(2)}`) : l
+        l.id === libroId ? agregarEstadoAlHistorial(l, 'tbr', `Comprado con $${costoTotal.toFixed(2)} (${paginas} páginas × $${costoPorPagina.toFixed(2)}/página)`) : l
       );
 
       return {
         ...state,
         libros: librosActualizados,
-        dineroActual: state.dineroActual - costoFijo,
+        dineroActual: state.dineroActual - costoTotal,
         librosCompradosConDinero: state.librosCompradosConDinero + 1
       };
     }


### PR DESCRIPTION
Standardize confirmation dialogs, enhance reset functionality to clear all data, and fix the money system to use a fixed book cost.

This PR addresses user feedback regarding inconsistent confirmation prompts, incomplete data resets, and an incorrect cost calculation for books when the money system is enabled. It ensures all confirmations use the app's custom dialogs, that resetting progress clears points and money, and that books are purchased with a fixed cost rather than a per-page calculation when the money system is active.

---

[Open in Web](https://cursor.com/agents?id=bc-f571de96-4284-4918-8e05-c144ca199ec6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f571de96-4284-4918-8e05-c144ca199ec6)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)