### PR TITLE
Exclude wishlist books from collection value

### DIFF
--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -50,13 +50,13 @@ const Statistics: React.FC = () => {
       ? librosConCalificacion.reduce((sum, book) => sum + (book.calificacion || 0), 0) / librosConCalificacion.length
       : 0;
     
-    // Calculate total collection value
+    // Calculate total collection value (excluyendo wishlist)
     const valorTotalColeccion = state.libros
-      .filter(book => book.precio && book.precio > 0)
+      .filter(book => book.estado !== 'wishlist' && book.precio && book.precio > 0)
       .reduce((sum, book) => sum + (book.precio || 0), 0);
     
-    // Calculate average book price
-    const librosConPrecio = state.libros.filter(book => book.precio && book.precio > 0);
+    // Calculate average book price (excluyendo wishlist)
+    const librosConPrecio = state.libros.filter(book => book.estado !== 'wishlist' && book.precio && book.precio > 0);
     const precioPromedio = librosConPrecio.length > 0 
       ? librosConPrecio.reduce((sum, book) => sum + (book.precio || 0), 0) / librosConPrecio.length
       : 0;


### PR DESCRIPTION
Exclude wishlist books from collection value and average price calculations in the Statistics component.

The `Statistics.tsx` component was incorrectly including wishlist books in the total collection value and average book price calculations, unlike the `ProgressBar.tsx` component which already excluded them. This change ensures that only owned books contribute to the collection's monetary value, aligning with the user's request.

---

[Open in Web](https://cursor.com/agents?id=bc-6450fcec-dd41-4a1c-af19-d6266506c675) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6450fcec-dd41-4a1c-af19-d6266506c675) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)